### PR TITLE
Catch child exit, clean up the terminal and exit too.

### DIFF
--- a/lib/App/Cleo.pm
+++ b/lib/App/Cleo.pm
@@ -41,6 +41,12 @@ sub run {
     ReadMode('raw');
     local $| = 1;
 
+    local $SIG{CHLD} = sub {
+        print "Child shell exited!\n";
+        ReadMode('restore');
+        exit;
+    };
+
     chomp @commands;
     @commands = grep { /^\s*[^\#;]\S+/ } @commands;
 


### PR DESCRIPTION
Your example includes an exit at the top, which leaves things in an unfortunate state.  This catches it, resets the tty and exits.
