### PR TITLE
POD correction - sleep for microseconds not milliseconds

### DIFF
--- a/lib/App/Cleo.pm
+++ b/lib/App/Cleo.pm
@@ -139,7 +139,7 @@ supported:
 
 =item delay
 
-Number of milliseconds to wait before displaying each character of the command.
+Number of microseconds to wait before displaying each character of the command.
 The default is C<25_000>.
 
 =item prompt


### PR DESCRIPTION
Minor POD fix (I don't think people would hang around for the demo if it was 25,000 milliseconds!)

thanks,
Michael
