### PR TITLE
Feature: add dot dot dot

### DIFF
--- a/bin/cleo
+++ b/bin/cleo
@@ -68,6 +68,12 @@ Within a command, C<%%%> (three percent signs) will cause C<cleo> to pause and
 wait for a keypress before displaying the rest of the command.  This is useful
 if you want to stop in the middle of a command to give some explanation.
 
+=item C<...>
+
+Commands starting with C<...> (three periods) are displayed and then executed
+without waiting for a keypress.  This is useful for running commands that you
+want the audience to see but that don't require interaction.
+
 =back
 
 Otherwise, C<cleo> displays and executes the commands verbatim.  Note that

--- a/lib/App/Cleo.pm
+++ b/lib/App/Cleo.pm
@@ -41,6 +41,12 @@ sub run {
     ReadMode('raw');
     local $| = 1;
 
+    local $SIG{CHLD} = sub {
+        print "Child shell exited!\n";
+        ReadMode('restore');
+        exit;
+    };
+
     chomp @commands;
     @commands = grep { /^\s*[^\#;]\S+/ } @commands;
 

--- a/lib/App/Cleo.pm
+++ b/lib/App/Cleo.pm
@@ -59,12 +59,14 @@ sub run {
         $self->do_cmd($cmd) and next CMD
             if $cmd =~ s/^!!!//;
 
+        my $just_do_it = $cmd =~ s/^\.\.\.//;
+
         print sprintf $self->{prompt}, $i;
 
         my @steps = split /%%%/, $cmd;
         while (my $step = shift @steps) {
 
-            my $key = ReadKey(0);
+            my $key = $just_do_it ? '' : ReadKey(0);
             print "\n" if $key =~ m/[srp]/;
 
             last CMD       if $key eq 'q';
@@ -77,7 +79,7 @@ sub run {
             print and usleep $self->{delay} for @chars;
         }
 
-        my $key = ReadKey(0);
+        my $key = $just_do_it ? '' : ReadKey(0);
         print "\n";
 
         last CMD       if $key eq 'q';


### PR DESCRIPTION
Sometimes it's useful to have a script run several lines in a row, without stopping, before pausing for me to say something deep and pithy.

This change adds support for lines that are prefixed with "...".  They're echoed to the screen and executed without waiting for a carriage return.

The change is implemented in _lib/App/Cleo.pm_ and documented in _bin/cleo_.
